### PR TITLE
Update VoiceProtocol for latest discord.py change

### DIFF
--- a/lavapy/player.py
+++ b/lavapy/player.py
@@ -260,7 +260,7 @@ class Player(discord.VoiceProtocol):
             }
             await self.node._send(voiceUpdate)
 
-    async def connect(self, *, timeout: float, reconnect: bool) -> None:
+    async def connect(self, *, timeout: float, reconnect: bool, self_deaf: bool = False, self_mute: bool = False) -> None:
         """|coro|
 
         Connects the player to a :class:`discord.VoiceChannel`.
@@ -272,7 +272,7 @@ class Player(discord.VoiceProtocol):
         reconnect: bool
             A bool stating if reconnection is expected.
         """
-        await self.guild.change_voice_state(channel=self.channel)
+        await self.guild.change_voice_state(channel=self.channel, self_mute=self_mute, self_deaf=self_deaf)
         self.node.players.append(self)
         self._connected = True
         logger.info(f"Connected to voice channel {self.channel.id}")


### PR DESCRIPTION
There was a breaking change a few days ago involving VoiceProtocol in the master branch of discord.py, you can see more information about it here https://github.com/Rapptz/discord.py/pull/7886.

This patch should be backwards compatible with v1.7 due to the usage of default arguments while simultaneously being forward compatible with the v2 breaking change.